### PR TITLE
Prevent automated issues from needed triage

### DIFF
--- a/src/tasks/add-triage-issue-if-new.ts
+++ b/src/tasks/add-triage-issue-if-new.ts
@@ -7,7 +7,8 @@ export class AddTriageIssueIfNew implements IssueHandler {
 
   public execute(issueInfo: IssueInfo, actions: Actions, notifier: Notifier): void {
     // already a status, ignore it
-    if (issueInfo.isClosed() || issueInfo.hasStatus() || issueInfo.repositoryName() !== "che" || issueInfo.milestone() != "" || issueInfo.hasSeverity()) {
+    if (issueInfo.isClosed() || issueInfo.hasStatus() || issueInfo.repositoryName() !== "che" || issueInfo.milestone() != "" || issueInfo.hasSeverity()
+       || issueInfo.hasLabel("automated")) {
       return;
     }
 


### PR DESCRIPTION
Do not add the "status/triage-needed" label to issues with the "automated" label.
This prevents unneeded triage of issues filed by scripts/bots.

Signed-off-by: Eric Williams <ericwill@redhat.com>